### PR TITLE
feat: Support switch docs version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -91,7 +91,7 @@ privacy_policy = "https://policies.google.com/privacy"
 
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [params.versions] set.
-version_menu = "Releases"
+version_menu = "Docs"
 
 # Flag used in the "version-banner" partial to decide whether to display a 
 # banner on every page indicating that this is an archived version of the docs.
@@ -106,6 +106,11 @@ version = "0.0"
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
 url_latest_version = "/"
+
+[[params.versions]]
+version = "latest"
+# url = "./docs" # If chinese document is avaliable
+url = '/docs'
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/OpenFunction/website"

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -2,9 +2,6 @@
 title: "v0.6.0 (latest)"
 linkTitle: "Docs"
 weight: 20
-menu:
-  main:
-    weight: 10
 ---
 Welcome to the OpenFunction documentation site!
 

--- a/content/zh/docs/_index.md
+++ b/content/zh/docs/_index.md
@@ -2,9 +2,6 @@
 title: "欢迎访问 OpenFunction"
 linkTitle: "文档"
 weight: 20
-menu:
-  main:
-    weight: 10
 ---
 [OpenFunction](https://github.com/OpenFunction/OpenFunction.git) 是一个云原生、开源的 FaaS（函数即服务）框架，旨在让开发人员专注于他们的开发意图，而不必关心底层运行环境和基础设施。用户只需提交一段代码，就可以生成事件驱动的、动态伸缩的 Serverless 工作负载。
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -6,6 +6,11 @@
 	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
 		<ul class="navbar-nav mt-2 mt-lg-0">
 			{{ $p := . }}
+			{{ if  .Site.Params.versions }}
+			<li class="nav-item dropdown mr-4 d-none d-lg-block">
+				{{ partial "navbar-version-selector.html" . }}
+			</li>
+			{{ end }}
 			{{ range .Site.Menus.main }}
 			<li class="nav-item mr-4 mb-2 mb-lg-0">
 				{{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
@@ -17,11 +22,6 @@
 				{{ $url := urls.Parse .URL }}
 				{{ $baseurl := urls.Parse $.Site.Params.Baseurl }}
 				<a class="nav-link{{if $active }} active{{end}} hide_zh_doc_class" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>{{ with .Pre}}{{ $pre }}{{ end }}<span{{if $active }} class="active"{{end}}>{{ .Name }}</span>{{ with .Post}}{{ $post }}{{ end }}</a>
-			</li>
-			{{ end }}
-			{{ if  .Site.Params.versions }}
-			<li class="nav-item dropdown mr-4 d-none d-lg-block">
-				{{ partial "navbar-version-selector.html" . }}
 			</li>
 			{{ end }}
 			{{ if  (gt (len .Site.Home.Translations) 0) }}


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

##159

Before:

![截屏2022-07-25 18 29 30](https://user-images.githubusercontent.com/33231138/180756626-dba50831-a2a3-46c4-b256-1f19e0e95fd9.png)

Now:

![截屏2022-07-26 10 03 14](https://user-images.githubusercontent.com/33231138/180906621-913cd1da-bb27-4624-a4cd-32ca1b9b0d42.png)

Docs detail page:
![截屏2022-07-25 18 34 43](https://user-images.githubusercontent.com/33231138/180757550-e88b9b4e-0248-4eaa-a69b-006b5953e7ca.png)

## note

If we want to add an old version for docs, we just need to add  the `[[params.versions]]`  field for conifg.toml.
